### PR TITLE
catch possible NumberFormatException

### DIFF
--- a/src/main/java/com/github/javaclub/jorm/common/Version.java
+++ b/src/main/java/com/github/javaclub/jorm/common/Version.java
@@ -74,7 +74,7 @@ public class Version implements Comparable {
 				}
 			}
 		}
-		catch (NoSuchElementException e) {
+		catch (NoSuchElementException | NumberFormatException e) {
 			throw new IllegalArgumentException("invalid format");
 		}
 


### PR DESCRIPTION
If the input parameter is invalid, Integer.parseInt(str) will throw a NumberFormatException, so this exception should be caught.
[
![image](https://user-images.githubusercontent.com/44200574/137831752-3c83aef9-9b52-425a-9a4e-2240176b8617.png)
](url)